### PR TITLE
Remove reference to fds_bits

### DIFF
--- a/src/honeevent.c
+++ b/src/honeevent.c
@@ -793,7 +793,7 @@ static void __add_files(struct hone_reader *reader, struct task_struct *task)
 		int i = j * __NFDBITS;
 		if (i >= fdt->max_fds)
 			break;
-		for (set = fdt->open_fds->fds_bits[j]; set; set >>= 1, i++) {
+		for (set = fdt->open_fds[j]; set; set >>= 1, i++) {
 			if (!(set & 1))
 				continue;
 			file = fdt->fd[i];


### PR DESCRIPTION
With Linux 3.4, struct fdtable has changed and fds_bits is no longer
accessible. Using now open_fds directly, but the validity of this change
should be verified.
