### PR TITLE
two changes.

### DIFF
--- a/src/hone_notify.h
+++ b/src/hone_notify.h
@@ -28,6 +28,8 @@ struct process_event {
 	pid_t ppid;
 	pid_t tgid;
 	uid_t uid;
+	uid_t euid;
+	uid_t loginuid;
 	gid_t gid;
 };
 

--- a/src/hone_notify_imp.c
+++ b/src/hone_notify_imp.c
@@ -326,8 +326,8 @@ static int packet_event_handler(struct notifier_block *nb,
 		return 0;
 	if ((event = alloc_hone_event(HONE_PACKET, GFP_ATOMIC))) {
 		struct packet_args *args = (typeof(args)) v;
-		event->packet.sock = (unsigned long) args->sk;
-		event->packet.pid = (unsigned long) (args->sk ? args->sk->sk_protinfo : 0);
+		event->packet.sock = args->sock;
+		event->packet.pid = args->pid;
 		event->packet.skb = skb_clone(args->skb, GFP_ATOMIC);
 		event->packet.dir = (val == PKTNOT_PACKET_IN);
 		atomic64_inc(&hone_received.packet);

--- a/src/hone_notify_imp.c
+++ b/src/hone_notify_imp.c
@@ -165,9 +165,15 @@ struct hone_event *__alloc_process_event(
 		pev->ppid = task->real_parent->pid;
 		pev->tgid = task->tgid;
 		if (pev->event == PROC_KTHD)
+		{
 			pev->comm = kstrndup(task->comm, sizeof(task->comm), flags);
+			BUG_ON(unlikely(!pev->comm));
+		}
 		else if (type == PROC_EXEC || (type == PROC_FORK && pev->ppid == 1))
+		{
 			pev->mm = task_mm(task);
+			BUG_ON(unlikely(!pev->mm));
+		}
 		rcu_read_lock();
 		cred = __task_cred(task);
 		pev->uid = __kuid_val(cred->uid);

--- a/src/hone_notify_imp.c
+++ b/src/hone_notify_imp.c
@@ -170,7 +170,9 @@ struct hone_event *__alloc_process_event(
 			pev->mm = task_mm(task);
 		rcu_read_lock();
 		cred = __task_cred(task);
-		pev->uid = __kuid_val(cred->euid);
+		pev->uid = __kuid_val(cred->uid);
+		pev->euid = __kuid_val(cred->euid);
+		pev->loginuid = __kuid_val(task->loginuid);
 		pev->gid = __kgid_val(cred->egid);
 		rcu_read_unlock();
 	}
@@ -423,4 +425,3 @@ EXPORT_SYMBOL(__alloc_socket_event);
 EXPORT_SYMBOL(free_hone_event);
 
 #endif // CONFIG_HONE_NOTIFY_COMBINED
-

--- a/src/honeevent_imp.c
+++ b/src/honeevent_imp.c
@@ -138,7 +138,7 @@ static unsigned int format_as_text(
 		struct process_event *pev = &event->process;
 		printbuf("%lu.%09lu %s %d %d %d %d\n",
 				event->ts.tv_sec, event->ts.tv_nsec, event_names[pev->event],
-				pev->pid, pev->ppid, pev->uid, pev->gid);
+				pev->pid, pev->ppid, pev->euid, pev->gid);
 		if (pev->mm) {
 			n--;
 			if (pev->event == PROC_KTHD)

--- a/src/packet_notify.h
+++ b/src/packet_notify.h
@@ -15,7 +15,8 @@
 #define PKTNOT_PACKET_OUT 2
 
 struct packet_args {
-	struct sock *sk;
+	unsigned long sock;
+	unsigned long pid;
 	struct sk_buff *skb;
 };
 

--- a/src/pcapng.c
+++ b/src/pcapng.c
@@ -308,6 +308,8 @@ static size_t format_process_block(struct process_event *event,
 		pos += block_opt_t(pos, 2, uint32_t, event_map[event->event]);
 	pos += block_opt_t(pos, 5, uint32_t, event->ppid);
 	pos += block_opt_t(pos, 6, uint32_t, event->uid);
+	pos += block_opt_t(pos, 8, uint32_t, event->euid);
+	pos += block_opt_t(pos, 9, uint32_t, event->loginuid);
 	pos += block_opt_t(pos, 7, uint32_t, event->gid);
 	if (event->mm) {
 		char *tmp, *ptr;

--- a/src/socket_lookup.h
+++ b/src/socket_lookup.h
@@ -175,7 +175,7 @@ static struct sock *lookup_v4_sock(const struct sk_buff *skb,
 
 #if defined(CONFIG_IPV6) || defined(CONFIG_IPV6_MODULE)
 #  if LINUX_VERSION_CODE >= KERNEL_VERSION(3,3,2)
-#    define SKIPHDR(...) ipv6_skip_exthdr(__VA_ARGS__, NULL)
+#    define SKIPHDR(...) ipv6_skip_exthdr(__VA_ARGS__, &fragment_offset)
 #  else
 #    define SKIPHDR ipv6_skip_exthdr
 #  endif
@@ -186,7 +186,7 @@ static int extract_icmp6_fields(const struct sk_buff *skb,
 {
 	struct ipv6hdr *inside_iph, _inside_iph;
 	struct icmp6hdr *icmph, _icmph;
-	__be16 *ports, _ports[2];
+	__be16 *ports, _ports[2], fragment_offset;
 	u8 inside_nexthdr;
 	int inside_hdrlen;
 
@@ -336,4 +336,3 @@ static struct sock *lookup_v6_sock(const struct sk_buff *skb,
 	return sk;
 }
 #endif
-

--- a/src/socket_lookup.h
+++ b/src/socket_lookup.h
@@ -175,7 +175,7 @@ static struct sock *lookup_v4_sock(const struct sk_buff *skb,
 
 #if defined(CONFIG_IPV6) || defined(CONFIG_IPV6_MODULE)
 #  if LINUX_VERSION_CODE >= KERNEL_VERSION(3,3,2)
-#    define SKIPHDR(...) ipv6_skip_exthdr(__VA_ARGS__, NULL)
+#    define SKIPHDR(...) ({__be16 _ignr; ipv6_skip_exthdr(__VA_ARGS__, &_ignr);})
 #  else
 #    define SKIPHDR ipv6_skip_exthdr
 #  endif
@@ -336,4 +336,3 @@ static struct sock *lookup_v6_sock(const struct sk_buff *skb,
 	return sk;
 }
 #endif
-

--- a/src/socket_notify.c
+++ b/src/socket_notify.c
@@ -8,6 +8,7 @@
  * Author: Brandon Carpenter
  */
 
+#include <linux/kprobes.h>
 #include <linux/version.h>
 #include <linux/module.h>
 #include <linux/notifier.h>
@@ -94,12 +95,10 @@ static inline int sock_notifier_notify(unsigned long event, struct sock *sk)
 	return result;
 }
 
-void inet_sock_destruct_hook(struct sock *sk)
+void inet_sock_destruct_handler(struct sock *sk)
 {
-	sock_notifier_notify(0xFFFFFFFF, sk);
-	sk->sk_destruct = inet_sock_destruct;
-	inet_sock_destruct(sk);
-	module_put(THIS_MODULE);
+	 sock_notifier_notify(0xFFFFFFFF, sk);
+        jprobe_return();
 }
 
 static inline void _finish_hook(struct sock *sk)
@@ -108,10 +107,8 @@ static inline void _finish_hook(struct sock *sk)
 		return;
 	BUG_ON(unlikely(sk->sk_destruct != inet_sock_destruct));
 	BUG_ON(unlikely(sk->sk_protinfo));
-	sk->sk_destruct = inet_sock_destruct_hook;
 	sk->sk_protinfo = (void *) (unsigned long)
 			(current->pid == current->tgid ? current->pid : current->tgid);
-	__module_get(THIS_MODULE);
 	sock_notifier_notify(0, sk);
 }
 
@@ -174,6 +171,11 @@ static int install_hook(const char *name,
 	return 0;
 }
 
+static struct jprobe inet_sock_destruct_jprobe = {
+	.kp.symbol_name = "inet_sock_destruct",
+	.entry = inet_sock_destruct_handler,
+};
+
 #ifdef CONFIG_SOCKET_NOTIFY_COMBINED
 #  define _STATIC
 #else
@@ -186,8 +188,15 @@ _STATIC int __init socket_notify_init(void)
 
 	if ((err = install_hook("IPv4", &inet_family_ops, &hooked_inet_family_ops)))
 		return err;
+	if ((err = register_jprobe(&inet_sock_destruct_jprobe)) < 0) {
+		printk(KERN_ERR "error registering inet_sock_destruct_jprobe\n");
+		sock_unregister(hooked_inet_family_ops.family);
+		reinstall_family("IPv4", &inet_family_ops);		
+		return err;
+	}
 #if defined(CONFIG_IPV6)
 	if ((err = install_hook("IPv6", &inet6_family_ops, &hooked_inet6_family_ops))) {
+		unregister_jprobe(&inet_sock_destruct_jprobe);
 		sock_unregister(hooked_inet_family_ops.family);
 		reinstall_family("IPv4", &inet_family_ops);
 		return err;
@@ -203,6 +212,7 @@ _STATIC void socket_notify_remove(void)
 	reinstall_family("IPv6", &inet6_family_ops);
 #endif
 	sock_unregister(hooked_inet_family_ops.family);
+	unregister_jprobe(&inet_sock_destruct_jprobe);
 	reinstall_family("IPv4", &inet_family_ops);
 	synchronize_net();
 }


### PR DESCRIPTION
Including the uid/loginuid with the euid can be helpful in the logs. We had talked about the jprobe for socket destruction but I realized that I neglected to send a patch.
